### PR TITLE
Hide document versioning resources

### DIFF
--- a/eve_docs/__init__.py
+++ b/eve_docs/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, current_app, jsonify
+from flask import Blueprint, render_template, jsonify
 from .config import get_cfg
 
 

--- a/eve_docs/config.py
+++ b/eve_docs/config.py
@@ -14,8 +14,11 @@ def get_cfg():
     for domain in capp.config['DOMAIN'].keys():
         if capp.config['DOMAIN'][domain]['item_methods'] or \
                 capp.config['DOMAIN'][domain]['resource_methods']:
-            cfg['domains'][domain] = {}
-            cfg['domains'][domain] = paths(domain)
+            # hide the shadow collection for document versioning
+            if 'VERSIONS' not in capp.config or not \
+                    domain.endswith(capp.config['VERSIONS']):
+                cfg['domains'][domain] = {}
+                cfg['domains'][domain] = paths(domain)
     return cfg
 
 

--- a/eve_docs/config.py
+++ b/eve_docs/config.py
@@ -12,7 +12,8 @@ def get_cfg():
     cfg['server_name'] = capp.config['SERVER_NAME']
     cfg['api_name'] = capp.config.get('API_NAME', 'API')
     for domain in capp.config['DOMAIN'].keys():
-        if capp.config['DOMAIN'][domain]['item_methods'] or capp.config['DOMAIN'][domain]['resource_methods']:
+        if capp.config['DOMAIN'][domain]['item_methods'] or \
+                capp.config['DOMAIN'][domain]['resource_methods']:
             cfg['domains'][domain] = {}
             cfg['domains'][domain] = paths(domain)
     return cfg


### PR DESCRIPTION
Hey there! I just added a feature to the Eve 0.4 develop branch called document versioning. The feature works by creating parallel shadow collections to store old copies of documents. This pull requests makes sure to hide those shadow collections from the API docs listing.

This is cool stuff by the way!
