### PR TITLE
Scheme shouldn't be prepended to the home URL if it's already present.

### DIFF
--- a/eve_docs/config.py
+++ b/eve_docs/config.py
@@ -5,9 +5,11 @@ from .labels import LABELS
 
 def get_cfg():
     cfg = {}
-    protocol = capp.config['PREFERRED_URL_SCHEME']
-    home = home_link()
-    cfg['base'] = '{}://{}'.format(protocol, home['href'])
+    base = home_link()['href']
+    if '://' not in base:
+        protocol = capp.config['PREFERRED_URL_SCHEME']
+        base = '{}://{}'.format(protocol, base['href'])
+    cfg['base'] = base
     cfg['domains'] = {}
     cfg['server_name'] = capp.config['SERVER_NAME']
     cfg['api_name'] = capp.config.get('API_NAME', 'API')


### PR DESCRIPTION
Currently, eve-docs unconditionally prepends the `PREFERRED_URL_SCHEME` the `home_link()` URL reported by the app. Eve's current development branch supports a new [`URL_PROTOCOL`](http://python-eve.org/config.html#global-configuration) setting, though. If it is set (because the user desires absolute URLs in HATEOAS output), then the scheme will already be present in the URL. When eve-docs prepends another scheme, the resulting URL is invalid. eve-docs should instead detect the presence of the scheme and refrain from making the change.

I'm submitting this change now because it's easy to implement in a backward-compatible way.

P.S. Thanks for your work on eve-docs. I'd love for you to release it on PyPI.
