### PR TITLE
Some improvements for parameter table display

### DIFF
--- a/eve_docs/config.py
+++ b/eve_docs/config.py
@@ -87,8 +87,8 @@ def methods(domain, pathtype, param=None):
             if method == 'POST':
                 ret[method]['params'].extend(schema(domain))
             elif method == 'PATCH':
-                ret[method]['params'].extend(schema(domain))
                 ret[method]['params'].append(identifier(domain))
+                ret[method]['params'].extend(schema(domain))
             elif pathtype == 'item':
                 ret[method]['params'].append(identifier(domain))
     return ret

--- a/eve_docs/config.py
+++ b/eve_docs/config.py
@@ -89,7 +89,7 @@ def methods(domain, pathtype, param=None):
             elif method == 'PATCH':
                 ret[method]['params'].extend(schema(domain))
                 ret[method]['params'].append(identifier(domain))
-            else:
+            elif pathtype == 'item':
                 ret[method]['params'].append(identifier(domain))
     return ret
 

--- a/eve_docs/templates/macros.html
+++ b/eve_docs/templates/macros.html
@@ -35,9 +35,11 @@
       </span>
     </div>
   </a>
+  {% if attrs.params %}
   <div id="{{ pathid }}-{{ method }}" class="collapse">
     {{ params_table(attrs.params) }}
   </div>
+  {%- endif %}
 </div>
 {%- endmacro %}
 

--- a/eve_docs/templates/macros.html
+++ b/eve_docs/templates/macros.html
@@ -36,28 +36,32 @@
     </div>
   </a>
   <div id="{{ pathid }}-{{ method }}" class="collapse">
-    <table class="table table-striped">
-      <thead>
-        <tr>
-          <th>Parameter</th>
-          <th>Type</th>
-          <th>Required</th>
-          <th>Other Attributes</th>
-        </tr>
-      </thead>
-    {% for param in attrs.params %}
-      <tr>
-        <td>{{ param.pop('name') }}</td>
-        <td>{{ param.pop('type') }}</td>
-        <td>{{ param.pop('required') }}</td>
-        <td>
-          {% for key, value in param.items() %}
-            {{ key }}: {{ value }}<br/>
-          {% endfor %}
-        </td>
-      </tr>
-    {% endfor %}
-    </table>
+    {{ params_table(attrs.params) }}
   </div>
 </div>
+{%- endmacro %}
+
+{% macro params_table(params) -%}
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Type</th>
+        <th>Required</th>
+        <th>Other Attributes</th>
+      </tr>
+    </thead>
+  {% for param in params %}
+    <tr>
+      <td>{{ param.pop('name') }}</td>
+      <td>{{ param.pop('type') }}</td>
+      <td>{{ param.pop('required') }}</td>
+      <td>
+        {% for key, value in param.items() %}
+          {{ key }}: {{ value }}<br/>
+        {% endfor %}
+      </td>
+    </tr>
+  {% endfor %}
+  </table>
 {%- endmacro %}


### PR DESCRIPTION
- Only add identifier for item methods
- Factor out parameters table into separate macro
- Suppress emtpy parameters table
- List identifier first in PATCH parameter table
