### PR TITLE
Fix to make domains like 'toplevel/sublevel' toggle

### DIFF
--- a/eve_docs/templates/macros.html
+++ b/eve_docs/templates/macros.html
@@ -1,12 +1,13 @@
 {% macro accordian(domain, paths) -%}
+{% set domain_id = domain|replace("/", "_") %}
   <div class="panel panel-default">
     <div class="panel-heading">
       <h4 class="panel-title"><a class="accordion-toggle" data-toggle="collapse" 
-        data-parent="accordion-{{ domain }}" href="#collapse-{{ domain }}">
+        data-parent="accordion-{{ domain_id }}" href="#collapse-{{ domain_id }}">
          /{{ domain }}
       </a></h4>
     </div>
-    <div id="collapse-{{ domain }}" class="panel-collapse collapse">
+    <div id="collapse-{{ domain_id }}" class="panel-collapse collapse">
       <div class="panel-body">
         {% for path, method in paths|dictsort %}
           {% for method, attrs in method.items() %}


### PR DESCRIPTION
Having id's including slashes in accordian macro like '#toggle-toplevel/sublevel' prevents toggeling. This fix just introduces a domain_id to compose the id's where the slashes are replaced with underscore.
