### PR TITLE
List all endpoints based on the url-map

### DIFF
--- a/eve_docs/config.py
+++ b/eve_docs/config.py
@@ -12,7 +12,7 @@ def get_cfg():
 
     The Hirarchy of Information is:
     1. list all endpoints from url_map
-    2. update with data out of DOMAIN
+    2. update with data out of DOMAIN (specific fields)
 
     :returns: dict with 'base', 'server_name', 'api_name', 'domains' for
         template

--- a/eve_docs/config.py
+++ b/eve_docs/config.py
@@ -5,6 +5,18 @@ import re
 
 
 def get_cfg():
+    """
+    Will get all necessary data out of the eve-app.
+    It reads 'SERVER_NAME', 'API_NAME', and'DOMAIN' out of app.config as well
+        as app.url_map
+
+    The Hirarchy of Information is:
+    1. list all endpoints from url_map
+    2. update with data out of DOMAIN
+
+    :returns: dict with 'base', 'server_name', 'api_name', 'domains' for
+        template
+    """
     cfg = {}
     base = home_link()['href']
     if '://' not in base:
@@ -16,7 +28,9 @@ def get_cfg():
     cfg['domains'] = {}
     cfg['server_name'] = capp.config['SERVER_NAME']
     cfg['api_name'] = capp.config.get('API_NAME', 'API')
+    # 1. parse rules from url_map
     cfg['domains'] = parse_map(capp.url_map)
+    # 2. Load schemas and paths from the config and update cfg
     domains = {}
     for domain, resource in list(capp.config['DOMAIN'].items()):
         if resource['item_methods'] or resource['resource_methods']:

--- a/eve_docs/config.py
+++ b/eve_docs/config.py
@@ -80,6 +80,12 @@ def identifier(resource):
 
 
 def schema(resource, field=None):
+    """extracts the detailed cerberus-schema of this endpoint
+    :param resource: the resource of the endpoint
+    :param field: the field for which the schema will be returned.
+        If no field specified, return a dict for all fields of the endpoint
+    :returns: schema as dict
+    """
     ret = []
     if field is not None:
         params = {field: resource['schema'][field]}
@@ -111,6 +117,12 @@ def schema(resource, field=None):
 
 
 def paths(domain, resource):
+    """returns the documentation of all endpoints of a domain for which we have
+    descriptions in the config
+    :param domain: the domain of the endpoints
+    :param resource: the resource-subdict of config['DOMAIN']
+    :returns: dict with paths and their documentation (methods, fields)
+    """
     ret = {}
     path = '/{0}'.format(resource.get('url', domain))
     path = re.sub(r'<(?:[^>]+:)?([^>]+)>', '{\\1}', path)
@@ -131,6 +143,13 @@ def paths(domain, resource):
 
 
 def methods(domain, resource, pathtype, param=None):
+    """extracts mathods and descriptions of a sepcified path
+    :param domain: the domain of the endpoint
+    :param resource: the resource-subdict of config['DOMAIN']
+    :param pathtype: String from ('item', 'resource')
+    :param param:
+    :returns: dict of methods and their documentation (fields)
+    """
     ret = {}
     if pathtype == 'additional_lookup':
         method = 'GET'
@@ -159,6 +178,12 @@ def pathparam(param):
 
 
 def get_label(domain, pathtype, method):
+    """a description of what the method does (e.g. PATCH will upadate an item)
+    :param domain: the domain of the endpoint
+    :param pathtype: String from ('item', 'resource')
+    :param method: the method for this label
+    :returns: description as a string
+    """
     verb = LABELS[method]
     if method == 'POST' or pathtype != 'resource':
         noun = capp.config['DOMAIN'][domain]['item_title']


### PR DESCRIPTION
For a project we had the problem that endpoints from blueprints are not listed by eve-docs.
(for example eve-docs does not document it's own endpoint, which is usually /docs)

Based on the url_map of the eve-app, I have added this functionality to eve-docs, it works out of the box. Endpoints from blueprints just get listet with their possible HTTP-Methods, endpoints from eve get documented by eve-docs with the schema and everything.

In addition I added some documentation.
